### PR TITLE
DJED-164: Extend PAB functionalities for managing local database

### DIFF
--- a/plutus-chain-index-core/src/Plutus/ChainIndex/Handlers.hs
+++ b/plutus-chain-index-core/src/Plutus/ChainIndex/Handlers.hs
@@ -196,10 +196,10 @@ getUtxoSetAtAddress pageQuery (toDbValue -> cred) = do
       tp           -> do
           let query = do
                 rowRef <- fmap _unspentOutputRowOutRef (all_ (unspentOutputRows db))
-                utxi <- fmap _unmatchedInputRowOutRef $ leftJoin_ (all_ (unmatchedInputRows db)) (\utxi -> rowRef ==. _unmatchedInputRowOutRef utxi)
                 rowCred <- leftJoin_
-                           (filter_ (\row -> _addressRowCred row ==. val_ cred) (all_ (addressRows db)))
-                           (\row -> _addressRowOutRef row ==. rowRef)
+                           (fmap _addressRowOutRef (filter_ (\row -> _addressRowCred row ==. val_ cred) (all_ (addressRows db))))
+                           (\row -> row ==. rowRef)
+                utxi <- leftJoin_ (fmap _unmatchedInputRowOutRef $ all_ (unmatchedInputRows db)) (\utxi -> rowRef ==. utxi)
                 guard_ (isNothing_ utxi)
                 guard_ (isJust_ rowCred)
                 pure rowRef
@@ -291,10 +291,10 @@ getUtxoSetWithCurrency pageQuery (toDbValue -> assetClass) = do
       tp           -> do
           let query = do
                 rowRef <- fmap _unspentOutputRowOutRef (all_ (unspentOutputRows db))
-                utxi <- fmap _unmatchedInputRowOutRef $ leftJoin_ (all_ (unmatchedInputRows db)) (\utxi -> rowRef ==. _unmatchedInputRowOutRef utxi)
                 rowClass <- leftJoin_
-                            (filter_ (\row -> _assetClassRowAssetClass row ==. val_ assetClass) (all_ (assetClassRows db)))
-                            (\row -> _assetClassRowOutRef row ==. rowRef)
+                            (fmap _assetClassRowOutRef (filter_ (\row -> _assetClassRowAssetClass row ==. val_ assetClass) (all_ (assetClassRows db))))
+                            (\row -> row ==. rowRef)
+                utxi <- leftJoin_ (fmap _unmatchedInputRowOutRef $ all_ (unmatchedInputRows db)) (\utxi -> rowRef ==. utxi)
                 guard_ (isNothing_ utxi)
                 guard_ (isJust_ rowClass)
                 pure rowRef

--- a/plutus-chain-index/src/Plutus/ChainIndex/Lib.hs
+++ b/plutus-chain-index/src/Plutus/ChainIndex/Lib.hs
@@ -93,6 +93,12 @@ withRunRequirements logConfig config cont = do
         \                                 AND input_row_out_ref = old.output_row_out_ref; \
         \END"
 
+    -- creating extra index to optimize utxoSetAtAddress and utxoSetWithCurrency queries
+    Sqlite.execute_ conn "DROP INDEX IF EXISTS unspent_index"
+    Sqlite.execute_ conn "DROP INDEX IF EXISTS unmatched_index"
+    Sqlite.execute_ conn "CREATE INDEX unspent_index on unspent_outputs (output_row_out_ref, output_row_tip__row_slot)"
+    Sqlite.execute_ conn "CREATE INDEX unmatched_index on unmatched_inputs (input_row_out_ref, input_row_tip__row_slot)"
+
   stateTVar <- newTVarIO mempty
   cont $ RunRequirements trace stateTVar pool (Config.cicSecurityParam config)
 

--- a/plutus-contract/src/Plutus/Contract/Effects.hs
+++ b/plutus-contract/src/Plutus/Contract/Effects.hs
@@ -32,6 +32,8 @@ module Plutus.Contract.Effects( -- TODO: Move to Requests.Internal
     _UnspentTxOutFromRef,
     _UtxoSetMembership,
     _UtxoSetAtAddress,
+    _DatumsAtAddress,
+    _UnspentTxOutSetAtAddress,
     _UtxoSetWithCurrency,
     _TxoSetAtAddress,
     _GetTip,
@@ -63,6 +65,8 @@ module Plutus.Contract.Effects( -- TODO: Move to Requests.Internal
     _TxIdResponse,
     _UtxoSetMembershipResponse,
     _UtxoSetAtResponse,
+    _DatumsAtResponse,
+    _UnspentTxOutsAtResponse,
     _UtxoSetWithCurrencyResponse,
     _TxIdsResponse,
     _TxoSetAtResponse,
@@ -302,7 +306,7 @@ instance Pretty ChainIndexResponse where
         DatumsAtResponse (QueryResponse datums _)  ->
           "Chain index datums from address response:" <+> hsep (fmap pretty datums)
         UnspentTxOutsAtResponse (QueryResponse txouts _) ->
-          "Chain index datums from address response:" <+> hsep (fmap pretty txouts)
+          "Unspent utxos from address response:" <+> hsep (fmap pretty txouts)
         UtxoSetWithCurrencyResponse (UtxosResponse tip txOutRefPage) ->
                 "Chain index UTxO with asset class response:"
             <+> "Current tip is"

--- a/plutus-pab-executables/plutus-pab.yaml.sample
+++ b/plutus-pab-executables/plutus-pab.yaml.sample
@@ -32,6 +32,12 @@ nodeServerConfig:
     - getWallet: 1
     - getWallet: 2
     - getWallet: 3
+
+  # Which cardano-node to use
+  # Options are
+  # - MockNode          (plutus-apps internal mock version of the node)
+  # - AlonzoNode        (cardano-node via socket connection)
+  # - NoChainSyncEvents (no node for chain sync events)
   pscNodeMode: MockNode
 
 chainIndexConfig:

--- a/plutus-pab-executables/test/full/Plutus/PAB/CoreSpec.hs
+++ b/plutus-pab-executables/test/full/Plutus/PAB/CoreSpec.hs
@@ -302,9 +302,13 @@ observableStateChangeTest = runScenario $ do
     env <- Core.askInstancesState @(Builtin TestContracts) @(Simulator.SimulatorState (Builtin TestContracts))
     instanceId <- Simulator.activateContract defaultWallet Currency
     createCurrency instanceId SimpleMPS{tokenName="my token", amount = 10000}
-    let stream = WS.observableStateChange instanceId env
-    vl2 <- liftIO (readN 2 stream) >>= \case { [_, newVal] -> pure newVal; _ -> throwError (OtherError "newVal not found")}
-    assertBool "observable state should change" (isJust $ getCurrency vl2)
+    s <- liftIO (STM.instanceState instanceId env)
+    case s of
+        Just state -> do
+            let stream = WS.observableStateChange state
+            vl2 <- liftIO (readN 2 stream) >>= \case { [_, newVal] -> pure newVal; _ -> throwError (OtherError "newVal not found")}
+            assertBool "observable state should change" (isJust $ getCurrency vl2)
+        Nothing -> assertBool "contract instance not found" False
 
 currencyTest :: TestTree
 currencyTest =

--- a/plutus-pab/src/Cardano/Node/Client.hs
+++ b/plutus-pab/src/Cardano/Node/Client.hs
@@ -76,10 +76,11 @@ runChainSyncWithCfg PABServerConfig { pscSocketPath
                                     , pscNetworkId
                                     , pscSlotConfig } =
     case pscNodeMode of
-      AlonzoNode ->
+      MockNode   ->
+          Left <$> MockClient.runChainSync' pscSocketPath pscSlotConfig
+      _ ->
           Right <$> Client.runChainSync' pscSocketPath
                                          pscSlotConfig
                                          (unNetworkIdWrapper pscNetworkId)
                                          []
-      MockNode   ->
-          Left <$> MockClient.runChainSync' pscSocketPath pscSlotConfig
+

--- a/plutus-pab/src/Cardano/Node/Types.hs
+++ b/plutus-pab/src/Cardano/Node/Types.hs
@@ -106,6 +106,7 @@ newtype NodeUrl = NodeUrl BaseUrl
 data NodeMode =
     MockNode -- ^ Connect to the PAB mock node.
     | AlonzoNode -- ^ Connect to an Alonzo node
+    | NoChainSyncEvents -- ^ Do not connect to any node for chain sync events. Connect to Alonzo node for slot notifications.
     deriving stock (Show, Eq, Generic)
     deriving anyclass (FromJSON, ToJSON)
 

--- a/plutus-pab/src/Plutus/PAB/App.hs
+++ b/plutus-pab/src/Plutus/PAB/App.hs
@@ -35,7 +35,7 @@ import Cardano.Api.Shelley (ProtocolParameters)
 import Cardano.BM.Trace (Trace, logDebug)
 import Cardano.ChainIndex.Types qualified as ChainIndex
 import Cardano.Node.Client (handleNodeClientClient, runChainSyncWithCfg)
-import Cardano.Node.Types (ChainSyncHandle, NodeMode (AlonzoNode, MockNode),
+import Cardano.Node.Types (ChainSyncHandle, NodeMode (MockNode),
                            PABServerConfig (PABServerConfig, pscBaseUrl, pscNetworkId, pscNodeMode, pscProtocolParametersJsonPath, pscSlotConfig, pscSocketPath))
 import Cardano.Protocol.Socket.Mock.Client qualified as MockClient
 import Cardano.Wallet.LocalClient qualified as LocalWalletClient
@@ -220,7 +220,7 @@ handleWalletEffect PABServerConfig { pscNodeMode = MockNode } _ w eff = do
         Nothing -> throwError RemoteWalletWithMockNodeError
         Just clientEnv ->
             runReader clientEnv $ WalletMockClient.handleWalletClient @IO w eff
-handleWalletEffect nodeCfg@PABServerConfig { pscNodeMode = AlonzoNode } cidM w eff = do
+handleWalletEffect nodeCfg cidM w eff = do
     clientEnvM <- ask @(Maybe ClientEnv)
     case clientEnvM of
         Nothing -> RemoteWalletClient.handleWalletClient nodeCfg cidM eff
@@ -264,9 +264,8 @@ mkEnv appTrace appConfig@Config { dbConfig
     dbPool <- dbConnect appTrace dbConfig
     txSendHandle <-
       case pscNodeMode of
-        AlonzoNode -> pure Nothing
-        MockNode   ->
-          liftIO $ Just <$> MockClient.runTxSender pscSocketPath
+        MockNode -> liftIO $ Just <$> MockClient.runTxSender pscSocketPath
+        _        -> pure Nothing
     -- This is for access to the slot number in the interpreter
     chainSyncHandle <- runChainSyncWithCfg $ nodeServerConfig appConfig
     appInMemContractStore <- liftIO initialInMemInstances

--- a/plutus-pab/src/Plutus/PAB/App.hs
+++ b/plutus-pab/src/Plutus/PAB/App.hs
@@ -42,7 +42,6 @@ import Cardano.Wallet.LocalClient qualified as LocalWalletClient
 import Cardano.Wallet.Mock.Client qualified as WalletMockClient
 import Cardano.Wallet.RemoteClient qualified as RemoteWalletClient
 import Cardano.Wallet.Types qualified as Wallet
-import Control.Concurrent.STM qualified as STM
 import Control.Lens (preview)
 import Control.Monad.Freer (Eff, LastMember, Member, interpret, reinterpret, reinterpret2, reinterpretN, type (~>))
 import Control.Monad.Freer.Error (Error, handleError, throwError)
@@ -128,7 +127,7 @@ appEffectHandlers storageBackend config trace BuiltinHandler{contractHandler} =
             env <- liftIO $ mkEnv trace config
             let Config { nodeServerConfig = PABServerConfig{pscSocketPath, pscSlotConfig, pscNodeMode, pscNetworkId = NetworkIdWrapper networkId}
                        , developmentOptions = DevelopmentOptions{pabRollbackHistory, pabResumeFrom} } = config
-            instancesState <- liftIO $ STM.atomically Instances.emptyInstancesState
+            instancesState <- liftIO Instances.emptyInstancesState
             blockchainEnv <- liftIO $ BlockchainEnv.startNodeClient pscSocketPath pscNodeMode pabRollbackHistory pscSlotConfig networkId pabResumeFrom instancesState
             pure (instancesState, blockchainEnv, env)
 

--- a/plutus-pab/src/Plutus/PAB/Core.hs
+++ b/plutus-pab/src/Plutus/PAB/Core.hs
@@ -302,6 +302,11 @@ instanceStateInternal instanceId = do
         >>= liftIO . Instances.instanceState instanceId
         >>= maybe (throwError $ ContractInstanceNotFound instanceId) pure
 
+-- | Delete the instance from the 'InstancesState' of the @PABEnvironment@
+removeInstance :: forall t env. ContractInstanceId -> PABAction t env ()
+removeInstance instanceId = do
+    asks @(PABEnvironment t env) instancesState >>= liftIO . Instances.removeInstance instanceId
+
 -- | Stop the instance.
 stopInstance :: forall t env. ContractInstanceId -> PABAction t env ()
 stopInstance instanceId = do
@@ -312,6 +317,7 @@ stopInstance instanceId = do
                 Active -> STM.putTMVar issStop () >> pure Nothing
                 _      -> pure (Just $ InstanceAlreadyStopped instanceId)
     traverse_ throwError r'
+    removeInstance instanceId
     Contract.deleteState @t instanceId
 
 -- | The 'Activity' of the instance.

--- a/plutus-pab/src/Plutus/PAB/Core.hs
+++ b/plutus-pab/src/Plutus/PAB/Core.hs
@@ -87,7 +87,7 @@ module Plutus.PAB.Core
     , timed
     ) where
 
-import Control.Applicative (empty)
+import Control.Applicative (empty, (<|>))
 import Control.Concurrent.STM (STM)
 import Control.Concurrent.STM qualified as STM
 import Control.Lens (view)
@@ -131,7 +131,7 @@ import Plutus.PAB.Events.ContractInstanceState (PartiallyDecodedResponse, fromRe
 import Plutus.PAB.Monitoring.PABLogMsg (PABMultiAgentMsg (ContractInstanceLog, EmulatorMsg))
 import Plutus.PAB.Timeout (Timeout)
 import Plutus.PAB.Timeout qualified as Timeout
-import Plutus.PAB.Types (PABError (ContractInstanceNotFound, InstanceAlreadyStopped, WalletError))
+import Plutus.PAB.Types (PABError (ContractInstanceNotFound, InstanceAlreadyStopped, OtherError, WalletError))
 import Plutus.PAB.Webserver.Types (ContractActivationArgs (ContractActivationArgs, caID, caWallet))
 import Wallet.API (Slot)
 import Wallet.API qualified as WAPI
@@ -518,11 +518,13 @@ waitForInstanceState ::
   PABAction t env ContractActivityStatus
 waitForInstanceState extract instanceId = do
   is <- instanceStateInternal instanceId
-  liftIO $ STM.atomically $ do
-    ms <- extract is
-    case ms of
-     Nothing     -> empty
-     Just status -> pure status
+  PABEnvironment{endpointTimeout} <- ask @(PABEnvironment t env)
+  timeout <- liftIO (Timeout.startTimeout endpointTimeout)
+  let waitAction = extract is >>= maybe empty pure
+  result <- liftIO (STM.atomically ((Left <$> STM.takeTMVar timeout) <|> (Right <$> waitAction)))
+  case result of
+    Left () -> throwError (OtherError "waitForInstanceState: Timeout")
+    Right r -> pure r
 
 
 -- | Wait until the instance state is updated with a response form an invoked endpoint.

--- a/plutus-pab/src/Plutus/PAB/Core.hs
+++ b/plutus-pab/src/Plutus/PAB/Core.hs
@@ -54,6 +54,7 @@ module Plutus.PAB.Core
     , instanceActivity
     -- * Querying the state
     , instanceState
+    , instanceStateInternal
     , observableState
     , waitForState
     , waitForInstanceState
@@ -86,7 +87,7 @@ module Plutus.PAB.Core
     , timed
     ) where
 
-import Control.Applicative (Alternative ((<|>)), empty)
+import Control.Applicative (empty)
 import Control.Concurrent.STM (STM)
 import Control.Concurrent.STM qualified as STM
 import Control.Lens (view)
@@ -292,19 +293,14 @@ callEndpointOnInstance ::
 callEndpointOnInstance instanceID ep value = do
     state <- asks @(PABEnvironment t env) instancesState
     timeoutVar <- asks @(PABEnvironment t env) endpointTimeout >>= liftIO . Timeout.startTimeout
-    liftIO
-        $ STM.atomically
-        $ Instances.callEndpointOnInstanceTimeout timeoutVar state (EndpointDescription ep) (JSON.toJSON value) instanceID
+    liftIO (Instances.callEndpointOnInstanceTimeout timeoutVar state (EndpointDescription ep) (JSON.toJSON value) instanceID >>= STM.atomically)
 
 -- | The 'InstanceState' for the instance. Throws a 'ContractInstanceNotFound' error if the instance does not exist.
 instanceStateInternal :: forall t env. ContractInstanceId -> PABAction t env Instances.InstanceState
 instanceStateInternal instanceId = do
-    instancesState <- asks @(PABEnvironment t env) instancesState
-    r <- liftIO $ STM.atomically $ (Left <$> Instances.instanceState instanceId instancesState)
-                               <|> (pure $ Right $ ContractInstanceNotFound instanceId)
-    case r of
-        Right err -> throwError err
-        Left s    -> pure s
+    asks @(PABEnvironment t env) instancesState
+        >>= liftIO . Instances.instanceState instanceId
+        >>= maybe (throwError $ ContractInstanceNotFound instanceId) pure
 
 -- | Stop the instance.
 stopInstance :: forall t env. ContractInstanceId -> PABAction t env ()
@@ -336,8 +332,7 @@ callEndpointOnInstance' ::
 callEndpointOnInstance' instanceID ep value = do
     state <- asks @(PABEnvironment t env) instancesState
     liftIO
-        $ STM.atomically
-        $ Instances.callEndpointOnInstance state (EndpointDescription ep) (JSON.toJSON value) instanceID
+        (Instances.callEndpointOnInstance state (EndpointDescription ep) (JSON.toJSON value) instanceID >>= STM.atomically)
 
 -- | Make a payment to a payment public key.
 payToPaymentPublicKey :: ContractInstanceId -> Wallet -> PaymentPubKeyHash -> Value -> PABAction t env CardanoTx
@@ -502,9 +497,8 @@ instanceState wallet instanceId = handleAgentThread wallet (Just instanceId) (Co
 
 -- | An STM transaction that returns the observable state of the contract instance.
 observableState :: forall t env. ContractInstanceId -> PABAction t env (STM JSON.Value)
-observableState instanceId = do
-    instancesState <- asks @(PABEnvironment t env) instancesState
-    pure $ Instances.observableContractState instanceId instancesState
+observableState instanceId =
+    Instances.observableContractState <$> instanceStateInternal @t @env instanceId
 
 -- | Wait until the observable state of the instance matches a predicate.
 waitForState :: forall t env a. (JSON.Value -> Maybe a) -> ContractInstanceId -> PABAction t env a
@@ -568,10 +562,9 @@ waitForTxOutStatusChange t = do
 -- | The list of endpoints that are currently open
 activeEndpoints :: forall t env. ContractInstanceId -> PABAction t env (STM [OpenEndpoint])
 activeEndpoints instanceId = do
-    instancesState <- asks @(PABEnvironment t env) instancesState
+    state <- instanceStateInternal instanceId
     pure $ do
-        is <- Instances.instanceState instanceId instancesState
-        fmap snd . Map.toList <$> Instances.openEndpoints is
+        fmap snd . Map.toList <$> Instances.openEndpoints state
 
 -- | Wait until the endpoint becomes active.
 waitForEndpoint :: forall t env. ContractInstanceId -> String -> PABAction t env ()
@@ -584,11 +577,8 @@ waitForEndpoint instanceId endpointName = do
 -- | Get exported transactions waiting to be balanced, signed and submitted by
 -- an external client.
 yieldedExportTxs :: forall t env. ContractInstanceId -> PABAction t env [ExportTx]
-yieldedExportTxs instanceId = do
-    instancesState <- asks @(PABEnvironment t env) instancesState
-    liftIO $ STM.atomically $ do
-        is <- Instances.instanceState instanceId instancesState
-        Instances.yieldedExportTxs is
+yieldedExportTxs instanceId =
+    instanceStateInternal instanceId >>= liftIO . STM.atomically . Instances.yieldedExportTxs
 
 currentSlot :: forall t env. PABAction t env (STM Slot)
 currentSlot = do
@@ -611,14 +601,11 @@ waitNSlots i = do
 -- | The set of all active contracts.
 activeContracts :: forall t env. PABAction t env (Set ContractInstanceId)
 activeContracts = do
-    instancesState <- asks @(PABEnvironment t env) instancesState
-    liftIO $ STM.atomically $ Instances.instanceIDs instancesState
+    asks @(PABEnvironment t env) instancesState >>= liftIO . Instances.instanceIDs
 
 -- | The final result of the instance (waits until it is available)
 finalResult :: forall t env. ContractInstanceId -> PABAction t env (STM (Maybe JSON.Value))
-finalResult instanceId = do
-    instancesState <- asks @(PABEnvironment t env) instancesState
-    pure $ Instances.finalResult instanceId instancesState
+finalResult instanceId = Instances.finalResult <$> instanceStateInternal instanceId
 
 -- | The value in a wallet.
 --
@@ -645,7 +632,9 @@ waitUntilFinished :: forall t env. ContractInstanceId -> PABAction t env (Maybe 
 waitUntilFinished i = finalResult i >>= liftIO . STM.atomically
 
 instancesWithStatuses :: forall t env. PABAction t env (Map ContractInstanceId ContractActivityStatus)
-instancesWithStatuses = askInstancesState @t @env >>= liftIO . STM.atomically . Instances.instancesWithStatuses
+instancesWithStatuses = do
+    s <- askInstancesState @t @env
+    liftIO (Instances.instancesWithStatuses s >>= STM.atomically)
 
 -- | Read the 'env' from the environment
 askUserEnv :: forall t env effs. Member (Reader (PABEnvironment t env)) effs => Eff effs env

--- a/plutus-pab/src/Plutus/PAB/Core.hs
+++ b/plutus-pab/src/Plutus/PAB/Core.hs
@@ -312,6 +312,7 @@ stopInstance instanceId = do
                 Active -> STM.putTMVar issStop () >> pure Nothing
                 _      -> pure (Just $ InstanceAlreadyStopped instanceId)
     traverse_ throwError r'
+    Contract.deleteState @t instanceId
 
 -- | The 'Activity' of the instance.
 instanceActivity :: forall t env. ContractInstanceId -> PABAction t env Activity

--- a/plutus-pab/src/Plutus/PAB/Core/ContractInstance.hs
+++ b/plutus-pab/src/Plutus/PAB/Core/ContractInstance.hs
@@ -129,7 +129,7 @@ startContractInstanceThread' ::
 startContractInstanceThread' ContractInstanceState{stmState} activeContractInstanceId runAppBackend a = do
   s <- startSTMInstanceThread'
     @t @m stmState runAppBackend a activeContractInstanceId
-  ask >>= void . liftIO . STM.atomically . InstanceState.insertInstance activeContractInstanceId s
+  ask >>= liftIO . InstanceState.insertInstance activeContractInstanceId s
   pure activeContractInstanceId
 
 -- | Create a new instance of the contract

--- a/plutus-pab/src/Plutus/PAB/Core/ContractInstance.hs
+++ b/plutus-pab/src/Plutus/PAB/Core/ContractInstance.hs
@@ -38,7 +38,7 @@ import Control.Concurrent (forkIO)
 import Control.Concurrent.STM (STM)
 import Control.Concurrent.STM qualified as STM
 import Control.Lens (preview)
-import Control.Monad (forM_, void)
+import Control.Monad (forM_)
 import Control.Monad.Freer (Eff, LastMember, Member, type (~>))
 import Control.Monad.Freer.Error (Error)
 import Control.Monad.Freer.Extras.Log (LogMessage, LogMsg, LogObserve, logDebug, logInfo)

--- a/plutus-pab/src/Plutus/PAB/Core/ContractInstance/BlockchainEnv.hs
+++ b/plutus-pab/src/Plutus/PAB/Core/ContractInstance/BlockchainEnv.hs
@@ -66,6 +66,7 @@ startNodeClient socket mode rollbackHistory slotConfig networkId resumePoint ins
         let resumePoints = maybeToList $ toCardanoPoint resumePoint
         void $ Client.runChainSync socket nullTracer slotConfig networkId resumePoints
           (\block -> handleSyncAction =<< processChainSyncEvent instancesState env block)
+      NoChainSyncEvents -> pure ()
     pure env
 
 -- | Deal with sync action failures from running this STM action. For now, we

--- a/plutus-pab/src/Plutus/PAB/Core/ContractInstance/STM.hs
+++ b/plutus-pab/src/Plutus/PAB/Core/ContractInstance/STM.hs
@@ -38,6 +38,7 @@ module Plutus.PAB.Core.ContractInstance.STM(
     , InstancesState
     , emptyInstancesState
     , insertInstance
+    , removeInstance
     , callEndpointOnInstance
     , callEndpointOnInstanceTimeout
     , observableContractState
@@ -388,6 +389,10 @@ finalResult InstanceState{issStatus} = do
 -- | Insert an 'InstanceState' value into the 'InstancesState'
 insertInstance :: ContractInstanceId -> InstanceState -> InstancesState -> IO ()
 insertInstance instanceID state (InstancesState m) = IORef.modifyIORef' m (Map.insert instanceID state)
+
+-- | Delete an instance from the 'InstancesState'
+removeInstance :: ContractInstanceId -> InstancesState -> IO ()
+removeInstance instanceID (InstancesState m) = IORef.modifyIORef' m (Map.delete instanceID)
 
 -- | Wait for the status of a transaction to change.
 waitForTxStatusChange :: TxStatus -> TxId -> BlockchainEnv -> STM TxStatus

--- a/plutus-pab/src/Plutus/PAB/Db/Beam/ContractStore.hs
+++ b/plutus-pab/src/Plutus/PAB/Db/Beam/ContractStore.hs
@@ -23,7 +23,7 @@ import Control.Monad (join)
 import Control.Monad.Freer (Eff, Member, type (~>))
 import Control.Monad.Freer.Error (Error, throwError)
 import Control.Monad.Freer.Extras (LogMsg)
-import Control.Monad.Freer.Extras.Beam (BeamEffect (..), addRows, selectList, selectOne, updateRows)
+import Control.Monad.Freer.Extras.Beam (BeamEffect (..), addRows, deleteRows, selectList, selectOne, updateRows)
 import Data.Aeson (FromJSON, ToJSON, decode, encode)
 import Data.ByteString.Builder (toLazyByteString)
 import Data.ByteString.Char8 qualified as B
@@ -165,3 +165,9 @@ handleContractStore = \case
             Just s -> guard_ ( ci ^. contractInstanceActive ==. val_ (s == Active) )
             _      -> pure ()
           pure ci
+
+  DeleteState instanceId ->
+    deleteRows
+      $ delete
+          (_contractInstances db)
+          (\ci -> ci ^. contractInstanceId ==. val_ (uuidStr instanceId))

--- a/plutus-pab/src/Plutus/PAB/Db/Memory/ContractStore.hs
+++ b/plutus-pab/src/Plutus/PAB/Db/Memory/ContractStore.hs
@@ -86,3 +86,6 @@ handleContractStore = \case
         fmap _contractDef <$> liftIO (IORef.readIORef instancesTVar)
     Contract.PutStartInstance{} -> pure ()
     Contract.PutStopInstance{} -> pure ()
+    Contract.DeleteState i -> do
+      instancesTVar <- unInMemInstances <$> ask @(InMemInstances t)
+      liftIO (IORef.modifyIORef' instancesTVar (Map.delete i))

--- a/plutus-pab/src/Plutus/PAB/Effects/Contract.hs
+++ b/plutus-pab/src/Plutus/PAB/Effects/Contract.hs
@@ -27,6 +27,7 @@ module Plutus.PAB.Effects.Contract(
     , getContracts
     , putStartInstance
     , putStopInstance
+    , deleteState
     -- * Storing and retrieving definitions of contracts
     , ContractDefinition(..)
     , addDefinition
@@ -123,6 +124,7 @@ data ContractStore t r where
     GetState :: ContractInstanceId -> ContractStore t (State t) -- ^ Retrieve the last recorded state of the contract instance
     PutStopInstance :: ContractInstanceId -> ContractStore t () -- ^ Record the fact that a contract instance has stopped
     GetContracts :: Maybe ContractActivityStatus -> ContractStore t (Map ContractInstanceId (ContractActivationArgs (ContractDef t))) -- ^ Get contracts with their activation args by status (all by default)
+    DeleteState :: ContractInstanceId -> ContractStore t () -- ^ Delete the state of a contract instance
 
 putStartInstance ::
     forall t effs.
@@ -191,6 +193,16 @@ getContracts ::
     -> Eff effs (Map ContractInstanceId (ContractActivationArgs (ContractDef t)))
 getContracts mStatus =
     let command :: ContractStore t (Map ContractInstanceId (ContractActivationArgs (ContractDef t))) = GetContracts mStatus
+    in send command
+
+deleteState ::
+    forall t effs.
+    ( Member (ContractStore t) effs
+    )
+    => ContractInstanceId
+    -> Eff effs ()
+deleteState i =
+    let command :: ContractStore t () = DeleteState i
     in send command
 
 -- | Get the definition of a running contract

--- a/plutus-pab/src/Plutus/PAB/Run/Cli.hs
+++ b/plutus-pab/src/Plutus/PAB/Run/Cli.hs
@@ -26,7 +26,7 @@ import Cardano.BM.Configuration (Configuration)
 import Cardano.BM.Data.Trace (Trace)
 import Cardano.ChainIndex.Server qualified as ChainIndex
 import Cardano.Node.Server qualified as NodeServer
-import Cardano.Node.Types (NodeMode (AlonzoNode, MockNode),
+import Cardano.Node.Types (NodeMode (MockNode),
                            PABServerConfig (pscNetworkId, pscNodeMode, pscSlotConfig, pscSocketPath), _AlonzoNode)
 import Cardano.Protocol.Socket.Type (epochSlots)
 import Cardano.Wallet.Mock.Server qualified as WalletServer
@@ -129,7 +129,7 @@ runConfigCommand _ ConfigCommandArgs{ccaTrace, ccaPABConfig = Config {nodeServer
                 (toMockNodeServerLog ccaTrace)
                 nodeServerConfig
                 ccaAvailability
-        AlonzoNode -> do
+        _        -> do
             available ccaAvailability
             -- The semantics of Command(s) is that once a set of commands are
             -- started if any finishes the entire application is terminated. We want
@@ -199,8 +199,8 @@ runConfigCommand
 -- Fork a list of commands
 runConfigCommand contractHandler c@ConfigCommandArgs{ccaAvailability, ccaPABConfig=Config {nodeServerConfig} } (ForkCommands commands) =
     let shouldStartMocks = case pscNodeMode nodeServerConfig of
-                             MockNode   -> True
-                             AlonzoNode -> False
+                             MockNode -> True
+                             _        -> False
         startedCommands  = filter (mockedServices shouldStartMocks) commands
      in void $ do
           putStrLn $ "Starting all commands (" <> show startedCommands <> ")."

--- a/plutus-pab/src/Plutus/PAB/Simulator.hs
+++ b/plutus-pab/src/Plutus/PAB/Simulator.hs
@@ -211,7 +211,7 @@ mkSimulatorHandlers slotCfg handleContractEffect =
     EffectHandlers
         { initialiseEnvironment =
             (,,)
-                <$> liftIO (STM.atomically   Instances.emptyInstancesState )
+                <$> liftIO (Instances.emptyInstancesState )
                 <*> liftIO (STM.atomically $ Instances.emptyBlockchainEnv Nothing def)
                 <*> liftIO (initialState @t)
         , handleContractStoreEffect =
@@ -461,7 +461,7 @@ handleChainControl slotCfg = \case
           currentTip <- getTip
           appendNewTipBlock currentTip txns slot
 
-        void $ liftIO $ STM.atomically $ BlockchainEnv.processMockBlock instancesState blockchainEnv txns slot
+        void $ liftIO (BlockchainEnv.processMockBlock instancesState blockchainEnv txns slot >>= STM.atomically)
 
         pure txns
     Chain.ModifySlot f -> runChainEffects @t @_ slotCfg (Chain.modifySlot f)

--- a/plutus-pab/src/Plutus/PAB/Simulator.hs
+++ b/plutus-pab/src/Plutus/PAB/Simulator.hs
@@ -636,6 +636,9 @@ handleContractStore = \case
         fmap _contractDef <$> liftIO (STM.readTVarIO instancesTVar)
     Contract.PutStartInstance{} -> pure ()
     Contract.PutStopInstance{} -> pure ()
+    Contract.DeleteState i -> do
+        instancesTVar <- view instances <$> (Core.askUserEnv @t @(SimulatorState t))
+        void $ liftIO $ STM.atomically $ STM.modifyTVar instancesTVar (Map.delete i)
 
 render :: forall a. Pretty a => a -> Text
 render = Render.renderStrict . layoutPretty defaultLayoutOptions . pretty

--- a/plutus-pab/src/Plutus/PAB/Timeout.hs
+++ b/plutus-pab/src/Plutus/PAB/Timeout.hs
@@ -8,8 +8,8 @@ module Plutus.PAB.Timeout (Timeout(..), startTimeout) where
 import Control.Concurrent (forkIO, threadDelay)
 import Control.Concurrent.STM (TMVar)
 import Control.Concurrent.STM qualified as STM
-import Control.Monad (void)
 import Data.Default (Default (..))
+import Data.Foldable (traverse_)
 import Data.Time.Units (Second, toMicroseconds)
 
 newtype Timeout = Timeout { unTimeout :: Maybe Second }
@@ -17,12 +17,13 @@ newtype Timeout = Timeout { unTimeout :: Maybe Second }
 instance Default Timeout where
     def = Timeout Nothing
 
--- | Create a 'TMVar' that is filled when the timeout expires.
+-- | Create a 'TMVar' that is filled when the timeout expires. If the timeout
+--   is 'Nothing', the 'TMVar' is never filled.
 startTimeout :: Timeout -> IO (TMVar ())
-startTimeout (Timeout Nothing) = STM.newTMVarIO ()
-startTimeout (Timeout (Just s)) = do
+startTimeout (Timeout t) = do
     tmv <- STM.newEmptyTMVarIO
-    void $ forkIO $ do
-        threadDelay $ fromIntegral $ toMicroseconds s
-        STM.atomically $ STM.putTMVar tmv ()
+    flip traverse_ t $ \s -> do
+        forkIO $ do
+            threadDelay $ fromIntegral $ toMicroseconds s
+            STM.atomically $ STM.putTMVar tmv ()
     pure tmv

--- a/plutus-pab/test/light/Cardano/Wallet/RemoteClientSpec.hs
+++ b/plutus-pab/test/light/Cardano/Wallet/RemoteClientSpec.hs
@@ -56,19 +56,17 @@ yieldToInstanceState = Hedgehog.property $ do
 
     let utx = emptyUnbalancedTx
     result <- liftIO $ do
-        iss <- STM.atomically $ do
-            iss <- emptyInstancesState
-            is <- emptyInstanceState
-            insertInstance cid is iss
-            pure iss
+        iss <- emptyInstancesState
+        is <- STM.atomically emptyInstanceState
+        insertInstance cid is iss
         yieldedRes <- runRemoteWalletEffects pp sc sl iss (Just cid) (YieldUnbalancedTx utx)
         pure $ fmap (,iss) yieldedRes
 
     case result of
       Left _ -> Hedgehog.assert False
       Right ((), iss) -> do
-          txs <- liftIO $ STM.atomically $ instanceState cid iss >>= yieldedExportTxs
-          List.length txs === 1
+          result <- liftIO $ instanceState cid iss >>= traverse (STM.atomically . yieldedExportTxs)
+          maybe (Hedgehog.assert False) (\txs -> List.length txs === 1) result
 
 -- | An error should be thrown when no contract instance id is provided.
 yieldNoCid :: Property
@@ -77,7 +75,7 @@ yieldNoCid = Hedgehog.property $ do
     sc <- Hedgehog.forAll Gen.genSlotConfig
     sl <- Hedgehog.forAll Gen.genSlot
     result <- liftIO $ do
-        iss <- STM.atomically emptyInstancesState
+        iss <- emptyInstancesState
         runRemoteWalletEffects pp sc sl iss Nothing (YieldUnbalancedTx emptyUnbalancedTx)
     case result of
       Left (OtherError _) -> Hedgehog.assert True


### PR DESCRIPTION
* Use `IORef` instead of `TVar` for `InstancesState` and `InMemInstances`
* Add `DeleteState` to `Contract` effect and call it from `stopInstance`
* Add `NoChainSyncEvents` constructor to `NodeMode`, which disables the chain sync handler that's used in `BlockchainEnv`

TO DO

- [ ] Stop waiting on instance updates after a timeout
  
<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested
