### PR TITLE
Reduction on state before insertion

### DIFF
--- a/plutus-chain-index-core/src/Plutus/ChainIndex/Handlers.hs
+++ b/plutus-chain-index-core/src/Plutus/ChainIndex/Handlers.hs
@@ -601,12 +601,13 @@ insertUtxoDb reducedTip txs utxoStates =
      performReduction ur umr outs
       | reducedTipIsSet reducedTip =
           -- ignore unspent outputs with a matching spent input before reduced tip
-          let (delete_ur, keep_ur) = List.partition (\e@(s, _) -> e `List.elem` umr && isReducedTip s reducedTip) ur
+          let !s_umr = Set.fromList umr
+              !(!delete_ur, !keep_ur) = Set.partition (\e@(s, _) -> Set.member e s_umr && isReducedTip s reducedTip) $ Set.fromList ur
               -- ignore spent input for which unspent outputs have been deleted
-              (delete_umr, keep_umr) = List.partition (`List.elem` delete_ur) umr
+              !(delete_umr, keep_umr) = Set.partition (\e -> Set.member e delete_ur) s_umr
               -- ignored txouts with a matching spent input before reduced tip
               outs' = List.filter (\(_, r) -> List.any (\(_, i) -> i == r) delete_umr) outs
-          in (keep_ur, keep_umr, outs')
+          in (Set.toList keep_ur, Set.toList keep_umr, outs')
       | otherwise = (ur, umr, outs)
 
      reducedTipIsSet :: Maybe Tip -> Bool

--- a/plutus-chain-index/src/Plutus/ChainIndex/Lib.hs
+++ b/plutus-chain-index/src/Plutus/ChainIndex/Lib.hs
@@ -89,12 +89,6 @@ withRunRequirements logConfig config cont = do
     -- Automatically delete the input when an output from a matching input/output pair is deleted.
     -- See reduceOldUtxoDb in Plutus.ChainIndex.Handlers
     Sqlite.execute_ conn "DROP TRIGGER IF EXISTS delete_matching_input"
-    Sqlite.execute_ conn
-        "CREATE TRIGGER delete_matching_input AFTER DELETE ON unspent_outputs \
-        \BEGIN \
-        \  DELETE FROM unmatched_inputs WHERE input_row_tip__row_slot = old.output_row_tip__row_slot \
-        \                                 AND input_row_out_ref = old.output_row_out_ref; \
-        \END"
 
     -- dropping these indexes if exists on start up
     -- the creation of these indexes are not performed dynamically accounting to the sync state


### PR DESCRIPTION
- [x] Perform block reduction on blocks acquired during syncing to avoid unnecessary insertions and deletions in DB
- [x] Replace UPDATE statements in `reduceOldUtxoDb` with only Delete statements such that:
1. all txouts for which a corresponding spent utxo with slot <= `reduced slot` are deleted from DB
2. all unspent utxo for which a corresponding spent utxo with slot <= `reduced slot` are deleted from DB
3. all spent utxo with slot <= `reduced slot` are deleted from DB. This can be done safetly as it is guaranteed by the node that the unspent utxo can be either in the same block or in previous blocks.
