### PR TITLE
adding more meaningful rollback error to support debugging

### DIFF
--- a/plutus-chain-index-core/plutus-chain-index-core.cabal
+++ b/plutus-chain-index-core/plutus-chain-index-core.cabal
@@ -109,6 +109,7 @@ library
     , containers
     , contra-tracer
     , cryptonite
+    , extra
     , data-default
     , exceptions
     , fingertree

--- a/plutus-chain-index-core/src/Plutus/ChainIndex/ChainIndexLog.hs
+++ b/plutus-chain-index-core/src/Plutus/ChainIndex/ChainIndexLog.hs
@@ -18,6 +18,7 @@ import Prettyprinter (Pretty (..), colon, viaShow, (<+>))
 data ChainIndexLog =
     InsertionSuccess Tip InsertUtxoPosition
     | ConversionFailed FromCardanoError
+    | AppendBlockSuccess [Tip]
     | RollbackSuccess Tip
     | Err ChainIndexError
     | TxNotFound TxId
@@ -38,6 +39,7 @@ instance Pretty ChainIndexLog where
       <+> pretty t
       <> "."
       <+> pretty p
+    AppendBlockSuccess tips -> "AppendBlockSuccess: Last 10 inserted tips: " <+> pretty tips
     RollbackSuccess t -> "RollbackSuccess: New tip is" <+> pretty t
     ConversionFailed cvError -> "Conversion failed: " <+> pretty cvError
     Err ciError -> "ChainIndexError:" <+> pretty ciError

--- a/plutus-chain-index-core/src/Plutus/ChainIndex/Handlers.hs
+++ b/plutus-chain-index-core/src/Plutus/ChainIndex/Handlers.hs
@@ -521,13 +521,13 @@ rollBackChainState targetPoint indexState =
       -- Already at the target point
      if | targetPoint `pointsToTip` currentTip -> Right (currentTip, indexState)
         -- The rollback happened sometimes after the current tip.
-        | not (targetPoint `UtxoState.pointLessThanTip` currentTip) -> Left $ TipMismatch currentTip targetPoint
+        | not (targetPoint `UtxoState.pointLessThanTip` currentTip) -> Left $ TipMismatch currentTip targetPoint (List.take 10 indexState)
         | otherwise ->
            let (_after, before) = List.span (\t -> targetPoint `UtxoState.pointLessThanTip` t) indexState
            in case getCurrentTip before of
                 Nothing -> Left $ OldPointNotFound targetPoint
                 Just oldTip | targetPoint `pointsToTip` oldTip -> Right (oldTip, before)
-                Just oldTip -> Left $ TipMismatch oldTip targetPoint
+                Just oldTip -> Left $ RollbackTipMismatch oldTip targetPoint (List.take 10 indexState)
 
 
 -- Use a batch size of 10000 so that we don't hit the sql too-many-variables

--- a/plutus-chain-index-core/src/Plutus/ChainIndex/Handlers.hs
+++ b/plutus-chain-index-core/src/Plutus/ChainIndex/Handlers.hs
@@ -458,6 +458,8 @@ appendBlocks _syncState blocks = do
         [ insertRows $ foldMap (\(tx, opt) -> if tpoStoreTx opt then fromTx tx else mempty) transactions
         , insertUtxoDb reducedTip (map (\(t, _) -> CAPI.toChainIndexTxEmptyScripts t) transactions) utxoStates
         ]
+    newIndex' <- get @ChainIndexState
+    logDebug $ AppendBlockSuccess $ List.take 10 newIndex'
 
   where
     -- | Reduces the number of tips. The given number corresponds to the node's security parameter.

--- a/plutus-chain-index-core/src/Plutus/ChainIndex/Handlers.hs
+++ b/plutus-chain-index-core/src/Plutus/ChainIndex/Handlers.hs
@@ -44,8 +44,8 @@ import Data.Set qualified as Set
 import Database.Beam (Columnar, Identity, SqlSelect, TableEntity, aggregate_, all_, countAll_, delete, filter_, in_,
                       limit_, nub_, select, val_)
 import Database.Beam.Backend.SQL (BeamSqlBackendCanSerialize)
-import Database.Beam.Query (HasSqlEqualityCheck, desc_, exists_, guard_, isNothing_, leftJoin_, orderBy_,
-                            (&&.), (/=.), (<=.), (==.), (>.))
+import Database.Beam.Query (HasSqlEqualityCheck, asc_, desc_, exists_, guard_, isNothing_, leftJoin_, orderBy_,
+                            (&&.), (/=.), (<=.), (==.), (>.), (>=.))
 import Database.Beam.Schema.Tables (zipTables)
 import Database.Beam.Sqlite (Sqlite)
 import Ledger (Datum, DatumHash (..), Slot, TxId, TxOutRef (..))
@@ -271,17 +271,30 @@ getUtxoSetAtAddress pageQuery (toDbValue -> cred) = do
       pure (UtxosResponse TipAtGenesis (Page pageQuery Nothing []))
     Just tp -> do
       -- select address txout first to optimize query
-      address_out_refs <- selectList $ select (fmap _addressRowOutRef (filter_ (\row -> _addressRowCred row ==. val_ cred) (all_ (addressRows db))))
-      let query = do
-            rowRef <- fmap _unspentOutputRowOutRef
-                      (filter_ (\output -> _unspentOutputRowOutRef output `in_` fmap val_ address_out_refs) (all_ (unspentOutputRows db)))
-            utxi <- leftJoin_ (fmap _unmatchedInputRowOutRef $ all_ (unmatchedInputRows db)) (\utxi -> rowRef ==. utxi)
-            guard_ (isNothing_ utxi)
-            pure rowRef
+      -- trick as a replacement for IN clause on SELECT
+      -- which is currently not supported by Beam.
+      moutRef <- selectOne
+                 $ select
+                 $ fmap _addressRowOutRef
+                 $ limit_ 1
+                 ( orderBy_ (asc_ . _addressRowOutRef)
+                   (filter_ (\row -> _addressRowCred row ==. val_ cred) (all_ (addressRows db))))
+      case moutRef of
+        Nothing -> do
+          -- no value found
+          pure (UtxosResponse tp (Page pageQuery Nothing []))
+        Just addr_out_ref -> do
+          let query = do
+                rowRef <- fmap _unspentOutputRowOutRef
+                          -- trick to force use of SEARCH TABLE on unspent_outputs
+                          (filter_ (\output -> _unspentOutputRowOutRef output >=. val_ addr_out_ref) (all_ (unspentOutputRows db)))
+                utxi <- leftJoin_ (fmap _unmatchedInputRowOutRef $ all_ (unmatchedInputRows db)) (\utxi -> rowRef ==. utxi)
+                guard_ (isNothing_ utxi)
+                pure rowRef
 
-      outRefs <- selectPage (fmap toDbValue pageQuery) query
-      let page = fmap fromDbValue outRefs
-      pure (UtxosResponse tp page)
+          outRefs <- selectPage (fmap toDbValue pageQuery) query
+          let page = fmap fromDbValue outRefs
+          pure (UtxosResponse tp page)
 
 
 getTxOutSetAtAddress ::


### PR DESCRIPTION
- [x] Adding more meaningful rollback errors to support debugging
- [x] Patch function `handleChainIndexEffects` in `Plutus.ChainIndex` to only update  `stateTVar` when the chain index state has changed. Indeed, this is essential so as to avoid the state updated by a sync event to be overridden by an old state. This situation can mainly happen when a sync event and a query event are both handled simultaneously such that they are both given the same old state such that the state provided by the sync event is written first.
- [x] Optimize `getUxtoSetAtAddress` to use inner join so that the proper table index is used
- [x] Optimize `getDatumAtAddress` to avoid multiple calls to `getDatumFromHash`
- [x] Optimize `getTxOutSetAtAddress` to avoid multiple calls to `getUtxoutFromRef`
- [x] Optimize `getUtxoSetWithCurrency` to avoid multiple calls to `getUtxoutFromRef`