### PR TITLE
adding support for Delete with IN Clause to properly used table index…

### DIFF
--- a/freer-extras/freer-extras.cabal
+++ b/freer-extras/freer-extras.cabal
@@ -63,6 +63,7 @@ library
     , bytestring
     , containers
     , data-default
+    , direct-sqlite
     , dlist
     , freer-simple
     , lens

--- a/freer-extras/freer-extras.cabal
+++ b/freer-extras/freer-extras.cabal
@@ -60,8 +60,10 @@ library
     , base           >=4.7 && <5
     , beam-core
     , beam-sqlite
+    , bytestring
     , containers
     , data-default
+    , dlist
     , freer-simple
     , lens
     , mtl

--- a/plutus-chain-index-core/src/Plutus/ChainIndex/Handlers.hs
+++ b/plutus-chain-index-core/src/Plutus/ChainIndex/Handlers.hs
@@ -613,7 +613,7 @@ insertUtxoDb reducedTip txs utxoStates =
               -- We can only delete a spent input if the unspent output is also in the list of acquired blocks
               -- Otherwise, the unspent output in DB will never be deleted. This will create an inconsistency
               !s_dur = Set.fromList delete_ur
-              !(!delete_umr, !keep_umr) = List.partition (e -> Set.member e s_dur) umr
+              !(!delete_umr, !keep_umr) = List.partition (\e -> Set.member e s_dur) umr
               -- ignored txouts with a matching deleted spent input before or at reduced tip
               !s_dumr = Set.fromList $ snd <$> delete_umr
               outs' = List.filter (\(_, r) -> not (Set.member r s_dumr)) outs


### PR DESCRIPTION
- [x] Adding support for `DELETED` with `IN` clause on `SELECT` statements to properly use table indexes when performing block reduction or rollbacks. In fact, the current version of Database.Beam does not support such a construct. The `in_` predicate only accepts a list of values but NOT a select statement. The new feature introduced in `Control.Monad.Freer.Extras.Beam` allows to specify DELETE statements of the following form:
```
DELETE FROM table1
WHERE row1 IN
( SELECT row2 FROM table2 WHERE condition )
```
This version is more efficient that an EXISTS clause as it directly use the table index created for row1 on table1.

- [x] Adding prepared statement support in Beam
- [x] Fixing bug when performing reduction on acquired blocks