### PR TITLE
Fixing race condition on InstancesState map

### DIFF
--- a/freer-extras/freer-extras.cabal
+++ b/freer-extras/freer-extras.cabal
@@ -70,7 +70,7 @@ library
     , mtl
     , openapi3
     , prettyprinter
-    , resource-pool
+    , resource-pool  <0.4.0.0
     , sqlite-simple
     , streaming
     , text

--- a/plutus-chain-index/plutus-chain-index.cabal
+++ b/plutus-chain-index/plutus-chain-index.cabal
@@ -85,7 +85,7 @@ library
     , lens
     , optparse-applicative
     , prettyprinter         >=1.1.0.1
-    , resource-pool
+    , resource-pool         <0.4.0.0
     , sqlite-simple
     , stm
     , time-units

--- a/plutus-pab/src/Plutus/PAB/Core/ContractInstance/STM.hs
+++ b/plutus-pab/src/Plutus/PAB/Core/ContractInstance/STM.hs
@@ -54,7 +54,7 @@ module Plutus.PAB.Core.ContractInstance.STM(
 import Control.Applicative (Alternative (empty))
 import Control.Concurrent.STM (STM, TMVar, TVar)
 import Control.Concurrent.STM qualified as STM
-import Control.Monad (guard, void)
+import Control.Monad (guard)
 import Data.Aeson (Value)
 import Data.Foldable (fold)
 import Data.IORef (IORef)
@@ -402,11 +402,11 @@ finalResult InstanceState{issStatus} = do
 
 -- | Insert an 'InstanceState' value into the 'InstancesState'
 insertInstance :: ContractInstanceId -> InstanceState -> InstancesState -> IO ()
-insertInstance instanceID state (InstancesState m) = void $ IORef.atomicModifyIORef' m (Map.insert instanceID state)
+insertInstance instanceID state (InstancesState m) = IORef.atomicModifyIORef' m (\s -> (Map.insert instanceID state s, ()))
 
 -- | Delete an instance from the 'InstancesState'
 removeInstance :: ContractInstanceId -> InstancesState -> IO ()
-removeInstance instanceID (InstancesState m) = void $ IORef.atomicModifyIORef' m (Map.delete instanceID)
+removeInstance instanceID (InstancesState m) = IORef.atomicModifyIORef' m (\s -> (Map.delete instanceID s, ()))
 
 -- | Wait for the status of a transaction to change.
 waitForTxStatusChange

--- a/plutus-pab/src/Plutus/PAB/Core/ContractInstance/STM.hs
+++ b/plutus-pab/src/Plutus/PAB/Core/ContractInstance/STM.hs
@@ -54,7 +54,7 @@ module Plutus.PAB.Core.ContractInstance.STM(
 import Control.Applicative (Alternative (empty))
 import Control.Concurrent.STM (STM, TMVar, TVar)
 import Control.Concurrent.STM qualified as STM
-import Control.Monad (guard)
+import Control.Monad (guard, void)
 import Data.Aeson (Value)
 import Data.Foldable (fold)
 import Data.IORef (IORef)
@@ -402,11 +402,11 @@ finalResult InstanceState{issStatus} = do
 
 -- | Insert an 'InstanceState' value into the 'InstancesState'
 insertInstance :: ContractInstanceId -> InstanceState -> InstancesState -> IO ()
-insertInstance instanceID state (InstancesState m) = IORef.modifyIORef' m (Map.insert instanceID state)
+insertInstance instanceID state (InstancesState m) = void $ IORef.atomicModifyIORef' m (Map.insert instanceID state)
 
 -- | Delete an instance from the 'InstancesState'
 removeInstance :: ContractInstanceId -> InstancesState -> IO ()
-removeInstance instanceID (InstancesState m) = IORef.modifyIORef' m (Map.delete instanceID)
+removeInstance instanceID (InstancesState m) = void $ IORef.atomicModifyIORef' m (Map.delete instanceID)
 
 -- | Wait for the status of a transaction to change.
 waitForTxStatusChange

--- a/plutus-pab/src/Plutus/PAB/Db/Memory/ContractStore.hs
+++ b/plutus-pab/src/Plutus/PAB/Db/Memory/ContractStore.hs
@@ -67,7 +67,7 @@ handleContractStore = \case
             -- adding new entry
             stateTVar <- liftIO (STM.newTVarIO state)
             let instState = InMemContractInstanceState{_contractDef = definition, _contractState = stateTVar}
-            liftIO $ IORef.modifyIORef' instancesTVar (Map.insert instanceId instState)
+            liftIO $ IORef.atomicModifyIORef' instancesTVar (\s -> (Map.insert instanceId instState s, ()))
           Just oldInstState -> do
             -- only update state
             liftIO $ STM.atomically $ do
@@ -88,4 +88,4 @@ handleContractStore = \case
     Contract.PutStopInstance{} -> pure ()
     Contract.DeleteState i -> do
       instancesTVar <- unInMemInstances <$> ask @(InMemInstances t)
-      liftIO (IORef.modifyIORef' instancesTVar (Map.delete i))
+      liftIO (IORef.atomicModifyIORef' instancesTVar (\s -> (Map.delete i s, ())))


### PR DESCRIPTION
- [x] Perform atomic modification of the InstancesState map to avoid race condition when several threads are trying to update the map simultaneously. Indeed the order in the map is not preserved and the following error is popping-up when executing the PAB on several cores: 
  - `EndpointCallError (InstanceDoesNotExist (ContractInstanceId {unContractInstanceId = 39b7dc6a-6304-4046-b070-d7b6c15f6ca5}))`

- [x] Restricting resource-pool version to be < 0.4.0.0
